### PR TITLE
recode: change sockaddr_in for addrinfo

### DIFF
--- a/BindingSocket.cpp
+++ b/BindingSocket.cpp
@@ -1,12 +1,12 @@
 #include "BindingSocket.hpp"
 
-ft::BindingSocket::BindingSocket(int domain, int service, int protocol, int port, u_long interface) : SimpleSocket(domain, service, protocol, port, interface)
+ft::BindingSocket::BindingSocket(std::string ip, std::string port) : SimpleSocket(ip, port)
 {
-	ConnectToNetwork(get_sock(), get_address());
+	ConnectToNetwork(get_SockFd(), get_AddrRes());
 	CheckConnection(binding);
 }
 
-void ft::BindingSocket::ConnectToNetwork(int sock, struct sockaddr_in address)
+void ft::BindingSocket::ConnectToNetwork(int sock, struct addrinfo *AddrRes)
 {
-	binding = bind(sock, (struct sockaddr *)&address, sizeof(address));
+	binding = bind(sock, AddrRes->ai_addr, AddrRes->ai_addrlen);
 }

--- a/BindingSocket.hpp
+++ b/BindingSocket.hpp
@@ -11,8 +11,8 @@ namespace ft
 		private:
 			int binding;
 		public:
-			BindingSocket(int domain, int service, int protocol, int port, u_long interface);
-			void ConnectToNetwork(int sock, struct sockaddr_in address);
+			BindingSocket(std::string ip, std::string port);
+			void ConnectToNetwork(int SockFd, struct addrinfo *AddrRes);
 	};
 }
 

--- a/ConnectingSocket.cpp
+++ b/ConnectingSocket.cpp
@@ -1,12 +1,12 @@
 #include "ConnectingSocket.hpp"
 
-ft::ConnectingSocket::ConnectingSocket(int domain, int service, int protocol, int port, u_long interface) : SimpleSocket(domain, service, protocol, port, interface)
+ft::ConnectingSocket::ConnectingSocket(std::string ip, std::string port) : SimpleSocket(ip, port)
 {
-	ConnectToNetwork(get_sock(), get_address());
+	ConnectToNetwork(get_SockFd(), get_AddrRes());
 	CheckConnection(connection);
 }
 
-void ft::ConnectingSocket::ConnectToNetwork(int sock, struct sockaddr_in address)
+void ft::ConnectingSocket::ConnectToNetwork(int sock, struct addrinfo *AddrRes)
 {
-	connection = connect(sock, (struct sockaddr *)&address, sizeof(address));
+	connection = connect(sock, AddrRes->ai_addr, AddrRes->ai_addrlen);
 }

--- a/ConnectingSocket.hpp
+++ b/ConnectingSocket.hpp
@@ -2,7 +2,6 @@
 # define CONNECTING_SOCKET_HPP
 
 #include <stdio.h>
-
 #include "SimpleSocket.hpp"
 
 namespace ft
@@ -12,8 +11,8 @@ namespace ft
 		private:
 			int connection;
 		public:
-			ConnectingSocket(int domain, int service, int protocol, int port, u_long interface);
-			void ConnectToNetwork(int sock, struct sockaddr_in address);
+			ConnectingSocket(std::string ip, std::string port);
+			void ConnectToNetwork(int SockFd, struct addrinfo *addrRes);
 	};
 }
 

--- a/ListeningSocket.cpp
+++ b/ListeningSocket.cpp
@@ -1,6 +1,6 @@
 #include "ListeningSocket.hpp"
 
-ft::ListeningSocket::ListeningSocket(int domain, int service, int protocol, int port, u_long interface, int bklg) : BindingSocket(domain, service, protocol, port, interface)
+ft::ListeningSocket::ListeningSocket(std::string ip, std::string port, int bklg) : BindingSocket(ip, port)
 {
 	backlog = bklg;
 	start_listening();
@@ -9,5 +9,5 @@ ft::ListeningSocket::ListeningSocket(int domain, int service, int protocol, int 
 
 void ft::ListeningSocket::start_listening()
 {
-	listening = listen(get_sock(), backlog); 
+	listening = listen(get_SockFd(), backlog); 
 }

--- a/ListeningSocket.hpp
+++ b/ListeningSocket.hpp
@@ -12,7 +12,7 @@ namespace ft
 			int backlog;
 			int listening;
 		public:
-			ListeningSocket(int domain, int service, int protocol, int port, u_long interface, int bklg);
+			ListeningSocket(std::string ip, std::string port, int bklg);
 			void start_listening();
 	};
 }

--- a/SimpleServer.cpp
+++ b/SimpleServer.cpp
@@ -1,7 +1,7 @@
 #include "SimpleServer.hpp"
 
-ft::SimpleServer::SimpleServer(int domain, int service, int protocol, int port, u_long interface, int bklg) {
-    socket = new ListeningSocket(domain, service, protocol, port, interface, bklg);
+ft::SimpleServer::SimpleServer(std::string ip, std::string port, int bklg) {
+	this->socket = new ListeningSocket(ip, port, bklg);
 }
 
 ft::ListeningSocket *ft::SimpleServer::GetSocket() {

--- a/SimpleServer.hpp
+++ b/SimpleServer.hpp
@@ -14,7 +14,7 @@ namespace ft
             virtual void Responder() = 0;
 
 		public:
-            SimpleServer(int domain, int service, int protocol, int port, u_long interface, int bklg);
+            SimpleServer(std::string ip, std::string port, int bklg);
             ListeningSocket *GetSocket();
             virtual void Launch() = 0;
     };

--- a/SimpleSocket.cpp
+++ b/SimpleSocket.cpp
@@ -1,13 +1,15 @@
 #include "SimpleSocket.hpp"
 
-ft::SimpleSocket::SimpleSocket(int domain, int service, int protocol, int port, u_long interface)
+ft::SimpleSocket::SimpleSocket(std::string ip, std::string port)
 {
 	// Define address structure
-	_address.sin_family = domain;
-	_address.sin_port = htons(port);
-	_address.sin_addr.s_addr = htonl(interface);
+	struct addrinfo info = {};
+
+	info.ai_family = AF_UNSPEC;
+	info.ai_socktype = SOCK_STREAM;
 	// Establish socket
-	sock = socket(domain, service, protocol);
+	CheckConnection(getaddrinfo(ip.c_str(), port.c_str(), &info, &res));
+	_SockFd = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
 }
 
 void ft::SimpleSocket::CheckConnection(int connection)
@@ -19,12 +21,12 @@ void ft::SimpleSocket::CheckConnection(int connection)
 	}
 }
 
-struct sockaddr_in ft::SimpleSocket::get_address()
+struct addrinfo *ft::SimpleSocket::get_AddrRes()
 {
-	return _address;
+	return res;
 }
 
-int ft::SimpleSocket::get_sock()
+int ft::SimpleSocket::get_SockFd()
 {
-	return sock;
+	return _SockFd;
 }

--- a/SimpleSocket.hpp
+++ b/SimpleSocket.hpp
@@ -1,25 +1,29 @@
 #ifndef SIMPLESOCKET_HPP
 # define SIMPLESOCKET_HPP
 
-#include <cstdio>
-#include <cstdlib>
-#include <sys/socket.h>
-#include <netinet/in.h>
+#include <cstdio> //perror
+#include <string> //string
+#include <cstdlib> //exit
+#include <sys/socket.h> //socket
+#include <sys/types.h>
+#include <netdb.h>
 
 namespace ft
 {
 	class SimpleSocket
 	{
 		private:
-			struct sockaddr_in	_address;
-			int sock;
+			struct addrinfo *res;
+			std::string ip;
+			std::string port;
+			int _SockFd;
 		public:
-			SimpleSocket(int domain, int service, int protocol, int port, u_long interface);
-			virtual void	ConnectToNetwork(int sock, struct sockaddr_in address) = 0;
+			SimpleSocket(std::string ip, std::string port);
+			virtual void	ConnectToNetwork(int sock, struct addrinfo *address) = 0;
 			void 			CheckConnection(int);
-			struct sockaddr_in get_address();
+			struct addrinfo *get_AddrRes();
 		
-		int get_sock();
+		int get_SockFd();
 
 	};
 }

--- a/TestServer.cpp
+++ b/TestServer.cpp
@@ -1,24 +1,24 @@
 #include "TestServer.hpp"
 
-ft::TestServer::TestServer() : SimpleServer(AF_INET, SOCK_STREAM, 0, 8080, INADDR_ANY, 10)
+ft::TestServer::TestServer() : SimpleServer("127.0.0.1", "8080", 10)
 {
-    Launch();
+	Launch();
 }
 
 void ft::TestServer::Accepter() {
-    struct sockaddr_in address = GetSocket()->get_address();
-    int addrLen = sizeof(address);
-    this->New_Socket = accept(GetSocket()->get_sock(), (struct sockaddr *)&address, (socklen_t *)&addrLen);
+    struct sockaddr_in clientaddr = {};
+	socklen_t addrLen = sizeof(clientaddr);
+    this->New_Socket = accept(GetSocket()->get_SockFd(), (struct sockaddr *)&clientaddr, (socklen_t *)&addrLen);
     memset(this->Buffer, 0, 3000);
     read(this->New_Socket, this->Buffer, 3000);
 }
 
 void ft::TestServer::Launch() {
     while (1) {
-        std::cout << "Waiting..." << std::endl;
-        Accepter();
-        Handler();
-        Responder();
+		std::cout << "Waiting..." << std::endl;
+		Accepter();
+		Handler();
+		Responder();
     }
 }
 
@@ -27,7 +27,6 @@ void ft::TestServer::Handler() {
 }
 
 void ft::TestServer::Responder() {
-    write(this->New_Socket, "teste", 6);
-    close(this->New_Socket);
+	send(this->New_Socket, "teste", 6, 0);
+	close(this->New_Socket);
 }
-

--- a/TestServer.hpp
+++ b/TestServer.hpp
@@ -13,7 +13,7 @@ namespace ft {
             void Handler();
             void Responder();
             int New_Socket;
-            char Buffer[3000];
+			char Buffer[3000];
         
         public:
             TestServer();


### PR DESCRIPTION
Bem basicamente eu recodei a estrutura padrão pra algo mais atual, dando uma olhada no link do PDF do cara q detalha melhor as coisas quanto no git do projeto das menina do sarau, a gente estava fazendo tudo de uma forma mais arcaica e velha, em si a maior mudança é q a estrutura sockaddr_in foi mudada para addrinfo q é bem mais simples tanto de se entender quanto de entendimento alem de funcionar melhor com a estrutura das informações q vão vir do arquivo de configuração mais pra frente, é uma mudança simples mas q se alinha melhor com a forma atual de fazer as coisas