### PR TITLE
Implement HTTP redirection

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -2,12 +2,16 @@ server {
   listen 8080
   server_name localhost
   root server_root
-  error_page 404 ./server_root/error_pages/error404.html
   client_max_body_size 2000000
 
   location / {
     index index.html
     allowed_methods GET
     cgi .py python3
+  }
+
+  location /search {
+      allowed_methods GET
+      return 301 https://duckduckgo.com/
   }
 }

--- a/include/DirectiveHandler.hpp
+++ b/include/DirectiveHandler.hpp
@@ -7,6 +7,7 @@
 #include <limits>
 #include <map>
 #include <sstream>
+#include <utility>
 
 #include "ServerConfig.hpp"
 #include "ServerUtils.hpp"
@@ -30,6 +31,7 @@ class DirectiveHandler {
     static const std::string ERR_ROOT;
     static const std::string ERR_CGI;
     static const std::string ERR_MAX_BODY_SIZE;
+    static const std::string ERR_RETURN;
 
     ServerConfig _cfg;
     std::map<std::string, DirectiveFunction> _directiveMap;
@@ -39,6 +41,7 @@ class DirectiveHandler {
     void _handleErrorPageDirective(std::istringstream &);
     void _handleRoot(std::istringstream &);
     void _handleCgi(std::istringstream &, Location &);
+    void _handleReturn(std::istringstream &, Location &);
     void _handleLocationDirective(std::istringstream &);
     void _handleAllowedMethodsDirective(std::istringstream &, Location &);
     void _handleIndexFile(std::istringstream &, Location &);

--- a/include/Location.hpp
+++ b/include/Location.hpp
@@ -8,8 +8,10 @@ struct Location {
     std::vector<std::string> allowedMethods;
     std::string indexFile;
     bool cgi;
+    std::pair<std::string, std::string> redirection;
 
-    Location() : path(), allowedMethods(), indexFile(), cgi(false) {}
+    Location()
+        : path(), allowedMethods(), indexFile(), cgi(false), redirection() {}
 
     bool hasPath() const { return !path.empty(); }
     bool hasAllowedMethods() const { return !allowedMethods.empty(); }

--- a/include/Location.hpp
+++ b/include/Location.hpp
@@ -19,4 +19,7 @@ struct Location {
     bool empty() const {
         return path.empty() && allowedMethods.empty() && indexFile.empty();
     }
+    bool redirectionSet() const {
+        return !(redirection.first.empty() || redirection.second.empty());
+    }
 };

--- a/include/ServerUtils.hpp
+++ b/include/ServerUtils.hpp
@@ -27,4 +27,8 @@ const std::string getAbsPath(const std::string &ex);
 
 std::vector<std::pair<std::string, std::string> > getDefaultErrorPages();
 
+bool withinRange(int n, std::pair<int, int> range);
+
+int stoi(const std::string &str);
+
 }  // namespace ServerUtils

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -11,40 +11,40 @@ Response::~Response() {}
 
 void Response::checkError() {
     _response = HTTP_VERSION;
-    if (_request.getErrorCode().empty() == false) {
-        errorResponse(ResponseUtils::StatusCodes(_request.getErrorCode()));
-        return;
+    if (!(_request.getErrorCode().empty())) {
+        return errorResponse(
+            ResponseUtils::StatusCodes(_request.getErrorCode()));
     }
-    if (_request.getLocation().empty() == false) {
-        if (ResponseUtils::IsMethodAllowed(_request.getLocation(),
-                                           _request.getMethod()) == false) {
-            errorResponse(ResponseUtils::StatusCodes("405"));
-            return;
-        } else {
-            _serverRoot = _request.getLocation().indexFile;
+    if (!(_request.getLocation().empty())) {
+        if (!(ResponseUtils::IsMethodAllowed(_request.getLocation(),
+                                             _request.getMethod()))) {
+            return errorResponse(ResponseUtils::StatusCodes("405"));
         }
+        _serverRoot = _request.getLocation().indexFile;
     }
-    if (_request.getHasBodyLimit() == true) {
-        if (_request.getBody().empty() == false &&
+    if (_request.getHasBodyLimit()) {
+        if (!_request.getBody().empty() &&
             _request.getBody().length() > _request.getMaxBodySize()) {
-            errorResponse(ResponseUtils::StatusCodes("413"));
-            return;
+            return errorResponse(ResponseUtils::StatusCodes("413"));
         }
     }
-    if (ServerUtils::fileExists(_serverRoot) == false) {
-        errorResponse(ResponseUtils::StatusCodes("404"));
-        return;
+    if (!_serverRoot.empty() && !ServerUtils::fileExists(_serverRoot)) {
+        return errorResponse(ResponseUtils::StatusCodes("404"));
     }
     generateResponse();
 }
 
 void Response::generateResponse() {
-    if (_request.getMethod() == "GET")
-        HandleGET();
-    else if (_request.getMethod() == "POST")
-        HandlePOST();
-    else if (_request.getMethod() == "DELETE")
-        HandleDELETE();
+    if (_request.getMethod() == "GET") {
+        return HandleGET();
+    }
+    if (_request.getMethod() == "POST") {
+        return HandlePOST();
+    }
+    if (_request.getMethod() == "DELETE") {
+        return HandleDELETE();
+    }
+    errorResponse(ResponseUtils::StatusCodes("405"));
 }
 
 void Response::HandleGET() {
@@ -52,12 +52,20 @@ void Response::HandleGET() {
     std::stringstream responseHead, responseBody, fullResponse;
     std::string fileExtension = ServerUtils::getExtension(_serverRoot);
 
-    /* if (false) {  // check redirect first
+    if (!_request.getLocation().empty() &&
+        _request.getLocation().redirectionSet()) {
+        std::string code = _request.getLocation().redirection.first,
+                    redirectedURL = _request.getLocation().redirection.second;
+        file.open(_request.getUrl().c_str(), std::ios::binary);
+        fullResponse << ResponseUtils::StatusCodes(code)
+                     << "Location: " << redirectedURL << "\r\n\r\n";
+        _response += fullResponse.str();
         return;
     }
-    if (false) {  // then, check folder and handle autoindex
-        return;
-    } */
+
+    // if (false) {  // then, check folder and handle autoindex
+    //     return;
+    // }
 
     if (_request.getUrl().find("script.py") != std::string::npos) {
         Cgi cgi = Cgi(_request, "GET");

--- a/srcs/ServerUtils.cpp
+++ b/srcs/ServerUtils.cpp
@@ -83,4 +83,15 @@ std::vector<std::pair<std::string, std::string> > getDefaultErrorPages() {
     return defaultErrorPages;
 }
 
+bool withinRange(int n, std::pair<int, int> range) {
+    return n >= range.first && n <= range.second;
+}
+
+int stoi(const std::string &str) {
+    std::istringstream iss(str);
+    int res;
+    iss >> res;
+    return res;
+}
+
 }  // namespace ServerUtils


### PR DESCRIPTION
Exemplo de config:

```
server {
  listen 8080
  server_name localhost
  root server_root
  client_max_body_size 2000000

  location / {
    index index.html
    allowed_methods GET
    cgi .py python3
  }

  location /search {
      allowed_methods GET
      return 301 https://duckduckgo.com/
  }
}
```

> O diretório especificado em `location` deve existir


Ao acessá-lo, o redirect será imediatamente feito